### PR TITLE
Add Spanish translation toggle

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -34,7 +34,11 @@
     <script>
       function googleTranslateElementInit() {
         new google.translate.TranslateElement(
-          { pageLanguage: 'en', includedLanguages: 'en,es', autoDisplay: false },
+          {
+            pageLanguage: 'en',
+            includedLanguages: 'en,es,ru,pt,hi,ar',
+            autoDisplay: false,
+          },
           'google_translate_element'
         );
       }

--- a/public/index.html
+++ b/public/index.html
@@ -24,11 +24,30 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
+    <div id="google_translate_element" style="display: none;"></div>
 
     <!-- AOS -->
     <script src="https://unpkg.com/aos@next/dist/aos.js"></script>
     <script>
       AOS.init();
     </script>
+    <script>
+      function googleTranslateElementInit() {
+        new google.translate.TranslateElement(
+          { pageLanguage: 'en', includedLanguages: 'en,es', autoDisplay: false },
+          'google_translate_element'
+        );
+      }
+
+      function translate(lang) {
+        const combo = document.querySelector('.goog-te-combo');
+        if (combo) {
+          combo.value = lang;
+          combo.dispatchEvent(new Event('change'));
+        }
+      }
+      window.translate = translate;
+    </script>
+    <script src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
   </body>
 </html>

--- a/src/components/Navbar/Navbar.js
+++ b/src/components/Navbar/Navbar.js
@@ -28,6 +28,15 @@ const Navbar = () => {
         }
     ];
 
+    const languages = [
+        { code: 'en', label: 'EN' },
+        { code: 'es', label: 'ES' },
+        { code: 'ru', label: 'RU' },
+        { code: 'pt', label: 'PT' },
+        { code: 'hi', label: 'HI' },
+        { code: 'ar', label: 'AR' }
+    ];
+
     return (
         <div className='main-nav'>
             <div className="container">
@@ -58,20 +67,16 @@ const Navbar = () => {
                                     <Link to="/contact">Book appointment</Link>
                                 </div>
                                 <div className="language-toggle btn-group" role="group">
-                                    <button
-                                        type="button"
-                                        className="btn btn-outline-secondary"
-                                        onClick={() => window.translate && window.translate('en')}
-                                    >
-                                        EN
-                                    </button>
-                                    <button
-                                        type="button"
-                                        className="btn btn-outline-secondary"
-                                        onClick={() => window.translate && window.translate('es')}
-                                    >
-                                        ES
-                                    </button>
+                                    {languages.map(({ code, label }) => (
+                                        <button
+                                            key={code}
+                                            type="button"
+                                            className="btn btn-outline-secondary"
+                                            onClick={() => window.translate && window.translate(code)}
+                                        >
+                                            {label}
+                                        </button>
+                                    ))}
                                 </div>
                             </div>
                         </div>

--- a/src/components/Navbar/Navbar.js
+++ b/src/components/Navbar/Navbar.js
@@ -53,8 +53,26 @@ const Navbar = () => {
                             </ul>
                             
                             {/* Navbar Button */}
-                            <div className="theme-btn">
-                                <Link to="/contact">Book appointment</Link>
+                            <div className="d-flex align-items-center">
+                                <div className="theme-btn me-3">
+                                    <Link to="/contact">Book appointment</Link>
+                                </div>
+                                <div className="language-toggle btn-group" role="group">
+                                    <button
+                                        type="button"
+                                        className="btn btn-outline-secondary"
+                                        onClick={() => window.translate && window.translate('en')}
+                                    >
+                                        EN
+                                    </button>
+                                    <button
+                                        type="button"
+                                        className="btn btn-outline-secondary"
+                                        onClick={() => window.translate && window.translate('es')}
+                                    >
+                                        ES
+                                    </button>
+                                </div>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- add Google Translate script and translate function to index.html
- add EN/ES toggle buttons in navbar to switch languages

## Testing
- `npm test -- --watchAll=false` (fails: react-scripts not found)
- `npm install` (fails: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_b_68a54f658a00832d92265d4ae033b8cd