### PR TITLE
Prevent navbar links wrapping onto multiple lines

### DIFF
--- a/src/components/Navbar/Navbar.scss
+++ b/src/components/Navbar/Navbar.scss
@@ -19,6 +19,8 @@
             }
         }
         .navbar-nav {
+            flex-wrap: nowrap;
+
             .nav-item {
                 .nav-link {
                     color: $color-black;


### PR DESCRIPTION
## Summary
- keep navigation links on a single row in the navbar

## Testing
- `npm test -- --watchAll=false` *(fails: sh: 1: react-scripts: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@testing-library%2fjest-dom)*

------
https://chatgpt.com/codex/tasks/task_b_68a8a124cbc8832db53f2210d2542a12